### PR TITLE
Proof aggregation improvements

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -291,12 +291,10 @@ func (l *L2OutputSubmitter) nextOutput(ctx context.Context, latestOutput binding
 	}
 
 	count := 0
-	for ; count < len(l.pending); count++ {
-		if l.pending[count].To.Number > latestSafe.Number {
-			break
-		}
+	for count < len(l.pending) && l.pending[count].To.Number < latestSafe.Number {
+		count++
 	}
-	if count == 0 {
+	if count <= 0 {
 		return nil, false, nil
 	}
 

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -316,7 +316,7 @@ func (l *L2OutputSubmitter) nextOutput(ctx context.Context, latestOutput binding
 		l.pending = append([]*Proposal{aggregated}, l.pending[batchLength:]...)
 		count -= batchLength - 1
 		l.Log.Info("Aggregated proofs",
-			"output", aggregated.Output.OutputRoot.String(), "blocks", batchLength, "remaining", count,
+			"output", aggregated.Output.OutputRoot.String(), "blocks", batchLength, "remaining", count-1,
 			"withdrawals", aggregated.Withdrawals, "from", aggregated.From.Number, "to", aggregated.To.Number)
 	}
 	proposal := l.pending[0]


### PR DESCRIPTION
This PR implements two improvements:
 - only generate 1000 proofs before attempting aggregation. If we're far behind, this ensures we test aggregation occasionally, rather than failing on a huge amount of proofs at once
 - only clear the pending if the enclave returns a non-recoverable error (like `invalid signer`), otherwise we lose a whole bunch of valid proofs