### PR TITLE
Fix aggregation

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -297,7 +297,7 @@ func (l *L2OutputSubmitter) nextOutput(ctx context.Context, latestOutput binding
 	}
 
 	count := 0
-	for count < len(l.pending) && l.pending[count].To.Number < latestSafe.Number {
+	for count < len(l.pending) && l.pending[count].To.Number <= latestSafe.Number {
 		count++
 	}
 	if count <= 0 {


### PR DESCRIPTION
#14 introduced an off-by-one where we don't actually ever include the safe head proof in the aggregate. Fix.