### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This removes the need for the 7-day challenge period, and allows for immediate w
 ├── <a href="./op-enclave">op-enclave</a>: Stateless transition function, for running in a AWS Nitro TEE
 ├── <a href="./op-proposer">op-proposer</a>: L2-Output Submitter, communicates with op-enclave and submits proposals to L1
 ├── <a href="./op-withdrawer">op-withdrawer</a>: Withdrawal utility for submitting withdrawals to L1
-├── <a href="./register-signer">register-signer</a>: Registers a enclave signer key from a Nitro attestation with the SystemConfigGlobal contract
+├── <a href="./register-signer">register-signer</a>: Registers an enclave signer key from a Nitro attestation with the SystemConfigGlobal contract
 ├── <a href="./testnet">testnet</a>: Dockerized testnet for running the op-enclave stack
 </pre>
 


### PR DESCRIPTION
I noticed a grammatical mistake in the "Directory Structure" section of the README. Specifically, the description for the `register-signer` directory uses "a enclave" instead of "**an enclave**."  

Since "enclave" begins with a vowel sound, the correct article is "an."

I've updated the text to fix this issue.