### PR TITLE
fix: Fix incorrect text output in ReportBalances function

### DIFF
--- a/op-withdrawer/example/main.go
+++ b/op-withdrawer/example/main.go
@@ -149,7 +149,7 @@ func ReportBalances(ctx context.Context, l1, l2 *ethclient.Client, addr common.A
 	l1b, _ := l1.BalanceAt(ctx, addr, nil)
 	l2b, _ := l2.BalanceAt(ctx, addr, nil)
 	if l1Balance != nil {
-		fmt.Printf("Balance change of %s on L2: %s, L3: %s\n\n", addr, new(big.Int).Sub(l1b, l1Balance), new(big.Int).Sub(l2b, l2Balance))
+		fmt.Printf("Balance change of %s on L1: %s, L2: %s\n\n", addr, new(big.Int).Sub(l1b, l1Balance), new(big.Int).Sub(l2b, l2Balance))
 	}
 	l1Balance = l1b
 	l2Balance = l2b


### PR DESCRIPTION
### Description 

While reviewing the `ReportBalances` function, I noticed an issue in the formatted text output. Specifically, the label `L3` was used instead of `L1` in the printed message.

**This is inconsistent with the logic of the function, which reports balance changes for L1 and L2 only.**  

The original code snippet:  

```go
fmt.Printf("Balance change of %s on L2: %s, L3: %s\n\n", addr, new(big.Int).Sub(l1b, l1Balance), new(big.Int).Sub(l2b, l2Balance))
```  

The corrected version:  

```go
fmt.Printf("Balance change of %s on L1: %s, L2: %s\n\n", addr, new(big.Int).Sub(l1b, l1Balance), new(big.Int).Sub(l2b, l2Balance))
```  
