### PR TITLE
Pass owner to DeployChain explicitly

### DIFF
--- a/contracts/script/DeployDeployChain.s.sol
+++ b/contracts/script/DeployDeployChain.s.sol
@@ -14,6 +14,7 @@ contract DeployDeployChain is Script, Artifacts {
         console.log("Deploying DeployChain implementation");
         vm.broadcast();
         DeployChain deployChain = new DeployChain{salt: _implSalt()}({
+            _owner: tx.origin,
             _proxyAdmin: mustGetAddress("ProxyAdmin"),
             _optimismPortal: mustGetAddress("OptimismPortalProxy"),
             _systemConfig: mustGetAddress("SystemConfigProxy"),

--- a/contracts/script/DeploySystem.s.sol
+++ b/contracts/script/DeploySystem.s.sol
@@ -201,6 +201,7 @@ contract DeploySystem is Deploy {
     function deployDeployChain() public broadcast returns (address addr_) {
         console.log("Deploying DeployChain implementation");
         DeployChain deployChain = new DeployChain{salt: _implSalt()}({
+            _owner: tx.origin,
             _proxyAdmin: mustGetAddress("ProxyAdmin"),
             _optimismPortal: mustGetAddress("OptimismPortalProxy"),
             _systemConfig: mustGetAddress("SystemConfigProxy"),

--- a/contracts/src/DeployChain.sol
+++ b/contracts/src/DeployChain.sol
@@ -77,6 +77,7 @@ contract DeployChain is Ownable {
     address public immutable protocolVersions;
 
     constructor(
+        address _owner,
         address _proxyAdmin,
         address _optimismPortal,
         address _systemConfig,
@@ -108,6 +109,7 @@ contract DeployChain is Ownable {
         l2OutputOracle = _l2OutputOracle;
         superchainConfig = _superchainConfig;
         protocolVersions = _protocolVersions;
+        transferOwnership(_owner);
     }
 
     function deployAddresses(uint256 chainID) external view returns (DeployAddresses memory) {


### PR DESCRIPTION
Currently the owner is the forge `Create2Deployer` address, which is broken.