### PR TITLE
Update output_oracle.go

### DIFF
--- a/bindings/output_oracle.go
+++ b/bindings/output_oracle.go
@@ -29,7 +29,7 @@ var (
 	_ = abi.ConvertType
 )
 
-// TypesOutputProposal is an auto generated low-level Go binding around an user-defined struct.
+// TypesOutputProposal is an auto generated low-level Go binding around a user-defined struct.
 type TypesOutputProposal struct {
 	OutputRoot    [32]byte
 	Timestamp     *big.Int

--- a/bindings/portal.go
+++ b/bindings/portal.go
@@ -29,7 +29,7 @@ var (
 	_ = abi.ConvertType
 )
 
-// TypesOutputRootProof is an auto generated low-level Go binding around an user-defined struct.
+// TypesOutputRootProof is an auto generated low-level Go binding around a user-defined struct.
 type TypesOutputRootProof struct {
 	Version                  [32]byte
 	StateRoot                [32]byte
@@ -37,7 +37,7 @@ type TypesOutputRootProof struct {
 	LatestBlockhash          [32]byte
 }
 
-// TypesWithdrawalTransaction is an auto generated low-level Go binding around an user-defined struct.
+// TypesWithdrawalTransaction is an auto generated low-level Go binding around a user-defined struct.
 type TypesWithdrawalTransaction struct {
 	Nonce    *big.Int
 	Sender   common.Address


### PR DESCRIPTION
In English, choosing “a” or “an” depends primarily on the initial sound rather than the spelling. The word “user” starts with the “yoo” sound, which is not a vowel sound, so the correct form is “a user-defined struct,” not “an user-defined struct.”