### PR TITLE
Fix broken link to SystemConfigGlobal.sol in register-signer README

### DIFF
--- a/tools/register-signer/README.md
+++ b/tools/register-signer/README.md
@@ -1,7 +1,7 @@
 # Signer registration utility
 
 This utility can be used to register an op-enclave signer key with the
-[SystemConfigGlobal](../contracts/src/SystemConfigGlobal.sol) contract.
+[SystemConfigGlobal](../../contracts/src/SystemConfigGlobal.sol) contract.
 
 ## Installation
 


### PR DESCRIPTION
Updated the path to the SystemConfigGlobal.sol contract in the tools/register-signer/README.md file to reflect its current location in the project. This resolves a broken link in the documentation and ensures users can easily navigate to the contract source.