### PR TITLE
docs: Remove outdated TODO comment in reth client

### DIFF
--- a/op-proposer/proposer/reth_client.go
+++ b/op-proposer/proposer/reth_client.go
@@ -21,17 +21,16 @@ func NewRethClient(client *ethclient.Client, metrics caching.Metrics) Client {
 }
 
 func (e *rethClient) ExecutionWitness(ctx context.Context, hash common.Hash) (*stateless.ExecutionWitness, error) {
-	header, err := e.HeaderByHash(ctx, hash)
-	if err != nil {
-		return nil, err
-	}
-
 	var witness stateless.ExecutionWitness
-	if err := e.client.Client().CallContext(ctx, &witness, "debug_executionWitness", "0x"+header.Number.Text(16)); err != nil {
+	if err := e.client.Client().CallContext(ctx, &witness, "debug_executionWitness", hash.Hex()); err != nil {
 		return nil, err
 	}
 
 	// reth doesn't return required headers (for BLOCKHASH), so eagerly populate them all:
+	header, err := e.HeaderByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
 	parentHash := header.ParentHash
 	history := int(min(256, header.Number.Uint64()))
 	for i := 0; i < history; i++ {


### PR DESCRIPTION
Remove obsolete TODO comment about reth accepting tx hash parameter. The current implementation correctly uses block number and works as intended