### PR TITLE
Add error handling to enclave entrypoint script

### DIFF
--- a/testnet/entrypoint-enclave.sh
+++ b/testnet/entrypoint-enclave.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -e
 
 exec ./op-enclave


### PR DESCRIPTION
Add `set -e` to entrypoint-enclave.sh to ensure the script exits immediately if any command fails. This improves error handling and prevents silent failures in the Docker container.