### PR TITLE
Remove redundant error check in ExecuteStateless

### DIFF
--- a/op-enclave/enclave/server.go
+++ b/op-enclave/enclave/server.go
@@ -285,10 +285,6 @@ func (s *Server) ExecuteStateless(
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}
-
-	if err != nil {
-		return nil, err
-	}
 	return &Proposal{
 		OutputRoot:    outputRoot,
 		Signature:     sig,


### PR DESCRIPTION
prune the unreachable if err != nil branch after signature generation so the flow is clearer and review noise goes away