### PR TITLE
Remove redundant error check in Server.ExecuteStateless

### DIFF
--- a/op-enclave/enclave/server.go
+++ b/op-enclave/enclave/server.go
@@ -285,10 +285,6 @@ func (s *Server) ExecuteStateless(
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}
-
-	if err != nil {
-		return nil, err
-	}
 	return &Proposal{
 		OutputRoot:    outputRoot,
 		Signature:     sig,


### PR DESCRIPTION
Drop the second if err != nil guard after signing proposals in Server.ExecuteStateless eliminate dead code while leaving the signing flow and returned data untouched