### PR TITLE
fix: remove redundant error check in ExecuteStateless

### DIFF
--- a/op-enclave/enclave/server.go
+++ b/op-enclave/enclave/server.go
@@ -285,10 +285,6 @@ func (s *Server) ExecuteStateless(
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}
-
-	if err != nil {
-		return nil, err
-	}
 	return &Proposal{
 		OutputRoot:    outputRoot,
 		Signature:     sig,


### PR DESCRIPTION
Removed duplicate error check after crypto.Sign call. The second check was unreachable since the first one already returns on error.

This looks like a copy-paste leftover - the error is properly handled in the first if statement, so the second one never executes.