### PR TITLE
docs: update copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Base
+Copyright (c) 2026 Base
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
New Year Update!

This PR updates the copyright year from 2025 to 2026 in the license files.

Happy coding in 2026!