### PR TITLE
ci: add Go checks to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,25 @@ jobs:
           cd contracts
           forge test -vvv
         id: test
+
+  go:
+    name: Go tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run go vet
+        run: |
+          go vet ./...
+
+      - name: Run go test
+        run: |
+          go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Release](https://img.shields.io/github/v/release/base/op-enclave)](https://github.com/base/op-enclave/releases)
-[![Build](https://github.com/base/op-enclave/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/base/op-enclave/actions/workflows/github-code-scanning/codeql)
+[![Release](https://img.shields.io/github/v/release/AdekunleBamz/op-enclave)](https://github.com/AdekunleBamz/op-enclave/releases)
+[![CI](https://github.com/AdekunleBamz/op-enclave/actions/workflows/test.yml/badge.svg)](https://github.com/AdekunleBamz/op-enclave/actions/workflows/test.yml)
 
 # op-enclave
 


### PR DESCRIPTION
PR Title:
Add Go checks to CI + fix README badges

PR Description:
This PR improves contributor feedback and repo accuracy by extending CI coverage to the Go code and fixing README badges that were pointing at a different repository.

Why
- The repo contains multiple Go modules/packages, but CI only validated the Foundry (Solidity) project, so Go regressions could merge unnoticed.
- The README badges referenced `base/op-enclave`, which is misleading for this repo/fork.

Changes
- Add a new GitHub Actions job that installs Go using `go.mod` and runs:
  - go vet ./...
  - go test ./...
- Update README badges to point to this repository’s:
  - Releases badge
  - CI workflow badge (.github/workflows/test.yml)

Verification
- GitHub Actions should run two jobs on PRs:
  - Foundry fmt/build/test (existing)
  - Go vet + Go test (new)
- Optional local verification:
  - go vet ./...
  - go test ./...