### PR TITLE
fix: prevent nil pointer panic in vsock proxy connection pool

### DIFF
--- a/op-enclave/cmd/server/main.go
+++ b/op-enclave/cmd/server/main.go
@@ -36,8 +36,8 @@ func main() {
 		}
 		_ = r.Body.Close()
 
-		conn := pool.Get().(*vsock.Conn)
-		if conn == nil {
+		conn, ok := pool.Get().(*vsock.Conn)
+		if !ok || conn == nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
## Description

The HTTP proxy in `cmd/server/main.go` can panic when `vsock.Dial` fails inside `sync.Pool.New`. When `New` returns `nil`, the single-value type assertion `pool.Get().(*vsock.Conn)` panics with *interface conversion: interface is nil, not *vsock.Conn*.

## Fix

Use the two-value form of the type assertion: `conn, ok := pool.Get().(*vsock.Conn)`. Also check `conn == nil` in case a nil `*vsock.Conn` was previously returned to the pool.

## Impact

Without this fix, if the vsock service is unavailable, any HTTP request to the proxy server will cause a panic and crash the entire server process. With this fix, the proxy returns HTTP 500 instead.

## Related

This was found during a security audit of op-enclave.