### PR TITLE
fix: harden HTTP servers with timeouts and request body size limit

### DIFF
--- a/op-enclave/cmd/enclave/main.go
+++ b/op-enclave/cmd/enclave/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"time"
 
 	enclave2 "github.com/base/op-enclave/op-enclave/enclave"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -26,7 +27,15 @@ func main() {
 	listener, err := vsock.Listen(1234, &vsock.Config{})
 	if err != nil {
 		log.Warn("Error opening vsock listener, running in HTTP mode", "error", err)
-		err = http.ListenAndServe(":1234", s)
+		srv := &http.Server{
+			Addr:              ":1234",
+			Handler:           s,
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      60 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
+		err = srv.ListenAndServe()
 	} else {
 		err = s.ServeListener(listener)
 	}

--- a/op-enclave/cmd/server/main.go
+++ b/op-enclave/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/mdlayher/vsock"
 )
@@ -28,6 +29,7 @@ func main() {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 		req, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Error reading request body: %v", err)
@@ -63,7 +65,15 @@ func main() {
 		_, _ = w.Write(raw)
 	}
 
-	err := http.ListenAndServe(":7333", http.HandlerFunc(handler))
+	srv := &http.Server{
+		Addr:              ":7333",
+		Handler:           http.HandlerFunc(handler),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	err := srv.ListenAndServe()
 	if err != nil {
 		log.Fatalf("Error starting server: %v", err)
 	}


### PR DESCRIPTION
## Description

Two hardening fixes for the HTTP servers in op-enclave:

### 1. HTTP timeouts (server + enclave)
Both `cmd/server/main.go` and `cmd/enclave/main.go` used `http.ListenAndServe()` which sets zero timeouts by default. An attacker can open slow connections (slowloris) and exhaust server resources.

**Fix:** Replace with `http.Server` with explicit `ReadHeaderTimeout: 10s`, `ReadTimeout: 30s`, `WriteTimeout: 30-60s`, and `IdleTimeout: 60s`.

### 2. Request body size limit (server)
`cmd/server/main.go:31` reads the request body with `io.ReadAll(r.Body)` without any size limit, allowing memory exhaustion via oversized POST bodies.

**Fix:** Wrap with `http.MaxBytesReader(w, r.Body, 1MB)` before reading.

## Impact

These are DoS vulnerabilities in the HTTP proxy facing external connections (:7333) and the enclave fallback HTTP server (:1234).